### PR TITLE
raise explicit error when unknown serializer

### DIFF
--- a/lib/restpack_serializer/factory.rb
+++ b/lib/restpack_serializer/factory.rb
@@ -1,18 +1,24 @@
-class RestPack::Serializer::Factory
-  def self.create(*identifiers)
-    serializers = identifiers.map { |identifier| self.classify(identifier) }
-    serializers.count == 1 ? serializers.first : serializers
-  end
+module RestPack::Serializer
 
-  private
+  class UnknownSerializer < StandardError; end
 
-  def self.classify(identifier)
-    normalised_identifier = identifier.to_s.underscore
-    [normalised_identifier, normalised_identifier.singularize].each do |format|
-      klass = RestPack::Serializer.class_map[format]
-      return klass.new if klass
+  class Factory
+
+    def self.create(*identifiers)
+      serializers = identifiers.map { |identifier| self.classify(identifier) }
+      serializers.count == 1 ? serializers.first : serializers
     end
 
-    raise "Invalid RestPack::Serializer : #{identifier}"
+    private
+
+    def self.classify(identifier)
+      normalised_identifier = identifier.to_s.underscore
+      [normalised_identifier, normalised_identifier.singularize].each do |format|
+        klass = RestPack::Serializer.class_map[format]
+        return klass.new if klass
+      end
+
+      raise UnknownSerializer.new("Unknown serializer class: #{identifier}")
+    end
   end
 end

--- a/spec/factory/factory_spec.rb
+++ b/spec/factory/factory_spec.rb
@@ -32,6 +32,7 @@ describe RestPack::Serializer::Factory do
     it "creates multi-word string" do
       factory.create("AlbumReview").should be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
+
     it "creates multi-word lowercase string" do
       factory.create("album_review").should be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
@@ -43,6 +44,17 @@ describe RestPack::Serializer::Factory do
     end
     it "creates multi-word class" do
       factory.create(MyApp::AlbumReview).should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
+  end
+
+  describe "unknown serializer word" do
+
+    it "raises a custom exception" do
+      unknown_serializer_class = "UnknownModelType"
+      message = "Unknown serializer class: #{unknown_serializer_class}"
+      expect do
+        factory.create(unknown_serializer_class).should
+      end.to raise_error(RestPack::Serializer::UnknownSerializer, message)
     end
   end
 


### PR DESCRIPTION
avoid use of runtime error to distinguish this event from other run time error classes.
