### PR TITLE
side load polymorphic relations

### DIFF
--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -16,7 +16,11 @@ module RestPack::Serializer::Paging
 
       if options.include_links
         result.links = self.links
-        Array(RestPack::Serializer::Factory.create(*options.include)).each do |serializer|
+        linkable_types = result.links.values.map { |link| link[:type].to_s }
+        includes = options.include.select do |include|
+          linkable_types.include?(include)
+        end
+        Array(RestPack::Serializer::Factory.create(*includes)).each do |serializer|
           result.links.merge! serializer.class.links
         end
       end

--- a/spec/factory/factory_spec.rb
+++ b/spec/factory/factory_spec.rb
@@ -53,7 +53,7 @@ describe RestPack::Serializer::Factory do
       unknown_serializer_class = "UnknownModelType"
       message = "Unknown serializer class: #{unknown_serializer_class}"
       expect do
-        factory.create(unknown_serializer_class).should
+        factory.create(unknown_serializer_class)
       end.to raise_error(RestPack::Serializer::UnknownSerializer, message)
     end
   end

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -175,6 +175,17 @@ describe RestPack::Serializer::Paging do
           page[:links]['artists.albums'].should_not == nil
         end
       end
+
+      context "with an unknown include link" do
+        let(:params) { { include: "unknown_link" } }
+
+        it "raises an exception" do
+          message = ":unknown_link is not a valid include for MyApp::Song"
+          expect do
+            page[:links]
+          end.to raise_error(RestPack::Serializer::InvalidInclude, message)
+        end
+      end
     end
 
     context "when filtering" do
@@ -254,6 +265,17 @@ describe RestPack::Serializer::Paging do
       it "returns custom page sizes" do
         page[:meta][:songs][:page_size].should == 3
         page[:meta][:songs][:page_count].should == 6
+      end
+    end
+
+    context "with an unknown include link" do
+      let(:params) { { include: "unknown_link" } }
+
+      it "raises an exception" do
+        message = ":unknown_link is not a valid include for MyApp::Song"
+        expect do
+          page[:links]
+        end.to raise_error(RestPack::Serializer::InvalidInclude, message)
       end
     end
   end


### PR DESCRIPTION
Pushes decision as to which serializer is used to the side load data builder to reflect on the polymorphic associations of each model
