### PR TITLE
updated restpack dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ end
 class AlbumSerializer
   include RestPack::Serializer
   attributes :id, :title, :year, :artist_id, :extras
+  optional :score
+
   can_include :artists, :songs
   can_filter_by :year
 
@@ -76,6 +78,18 @@ end
 
 ```ruby
 AlbumSerializer.as_json(album, { admin?: true })
+```
+
+All `attributes` are serialized by default. If you'd like to skip an attribute, you can pass an option in the `@context` as follows:
+
+```ruby
+AlbumSerializer.as_json(album, { include_title?: false })
+```
+
+You can also define `optional` attributes which aren't included by default. To include:
+
+```ruby
+AlbumSerializer.as_json(album, { include_score?: true })
 ```
 
 ## Exposing an API
@@ -114,8 +128,7 @@ AlbumSerializer.page(params, Albums.where("year < 1950"), { admin?: true })
 ```
 
 Other features:
- * [Dynamically Include/Exclude Attributes](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L42)
- * [Custom Attributes Hash](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L46)
+ * [Custom Attributes Hash](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L55)
 
 ## Paging
 

--- a/lib/restpack_serializer.rb
+++ b/lib/restpack_serializer.rb
@@ -16,5 +16,13 @@ module RestPack
     def self.setup
       yield @@config
     end
+
+    def self.select_association_serializer(association)
+      begin
+        RestPack::Serializer::Factory.create(association.name.to_s.classify)
+      rescue RestPack::Serializer::UnknownSerializer
+        RestPack::Serializer::Factory.create(association.class_name)
+      end
+    end
   end
 end

--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -49,7 +49,8 @@ module RestPack::Serializer::Attributes
         define_method name do
           value = self.default_href if name == :href
           if @model.is_a?(Hash)
-            value ||= @model[name] || @model[name.to_s]
+            value = @model[name]
+            value = @model[name.to_s] if value.nil?
           else
             value ||= @model.send(name)
           end

--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -38,7 +38,11 @@ module RestPack::Serializer::Attributes
       unless method_defined?(name)
         define_method name do
           value = self.default_href if name == :href
-          value ||= @model.send(name)
+          if @model.is_a?(Hash)
+            value ||= @model[name] || @model[name.to_s]
+          else
+            value ||= @model.send(name)
+          end
           value = value.to_s if name == :id
           value
         end

--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -14,6 +14,10 @@ module RestPack::Serializer::Attributes
       attrs.each { |attr| attribute attr }
     end
 
+    def optional(*attrs)
+      attrs.each { |attr| optional_attribute attr }
+    end
+
     def transform(attrs = [], transform_lambda)
       attrs.each { |attr| transform_attribute(attr, transform_lambda) }
     end
@@ -34,23 +38,44 @@ module RestPack::Serializer::Attributes
       define_include_method name
     end
 
+    def optional_attribute(name, options={})
+      add_to_serializable(name, options)
+      define_attribute_method name
+      define_optional_include_method name
+    end
+
     def define_attribute_method(name)
       unless method_defined?(name)
         define_method name do
           value = self.default_href if name == :href
-          value ||= @model.send(name)
+          if @model.is_a?(Hash)
+            value = @model[name]
+            value = @model[name.to_s] if value.nil?
+          else
+            value ||= @model.send(name)
+          end
           value = value.to_s if name == :id
           value
         end
       end
     end
 
-    def define_include_method(name)
+    def define_optional_include_method(name)
+      define_include_method(name, false)
+    end
+
+    def define_include_method(name, include_by_default=true)
       method = "include_#{name}?".to_sym
 
       unless method_defined?(method)
-        define_method method do
-          @context[method].nil? || @context[method]
+        if include_by_default
+          define_method method do
+            @context[method].nil? || @context[method]
+          end
+        else
+          define_method method do
+            @context[method].present?
+          end
         end
       end
     end

--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -20,9 +20,10 @@ module RestPack::Serializer::Paging
         includes = options.include.select do |include|
           linkable_types.include?(include)
         end.map do |include|
-          association_from_include(include).class_name
+          association_from_include(include)
         end
-        Array(RestPack::Serializer::Factory.create(*includes)).each do |serializer|
+        includes.map do |assocation|
+          serializer = RestPack::Serializer.select_association_serializer(assocation)
           result.links.merge! serializer.class.links
         end
       end

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -18,7 +18,7 @@ module RestPack
       def side_load_has_many
         has_association_relation do |options|
           if join_table = @association.options[:through]
-            options.scope = options.scope.joins(join_table)
+            options.scope = options.scope.joins(join_table).distinct
             association_fk = @association.through_reflection.foreign_key.to_sym
             options.filters = { join_table => { association_fk => model_ids } }
           else

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -9,8 +9,8 @@ module RestPack
       end
 
       def side_load_belongs_to
-        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq
-        side_load = @association.klass.find(foreign_keys)
+        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq.compact
+        side_load = foreign_keys.any? ? @association.klass.find(foreign_keys) : []
         json_model_data = side_load.map { |model| @serializer.as_json(model) }
         { @association.plural_name.to_sym => json_model_data, meta: { } }
       end

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -8,9 +8,10 @@ module RestPack
       end
 
       def side_load_belongs_to
-        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq.compact
-        side_load = foreign_keys.any? ? @association.klass.find(foreign_keys) : []
-        json_model_data = side_load.map { |model| model_serializer(model).as_json(model) }
+        side_loads = @models.map { |model| model.send(@association.name) }.compact
+        json_model_data = side_loads.map do |model|
+          model_serializer(model).as_json(model)
+        end
         { @association.plural_name.to_sym => json_model_data, meta: { } }
       end
 

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -50,11 +50,11 @@ module RestPack
 
       def has_association_relation
         return {} if @models.empty?
-        serializer_class = RestPack::Serializer::Factory.create(@association.class_name).class
-        options = RestPack::Serializer::Options.new(serializer_class)
+        serializer = RestPack::Serializer.select_association_serializer(@association)
+        options = RestPack::Serializer::Options.new(serializer.class)
         yield options
         options.include_links = false
-        serializer_class.page_with_options(options)
+        serializer.class.page_with_options(options)
       end
     end
   end

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -8,17 +8,16 @@ module RestPack
       end
 
       def side_load_belongs_to
-        side_loads = @models.map { |model| model.send(@association.name) }
-        json_model_data = side_loads.map do |model|
-          model_serializer(model).as_json(model)
-        end
+        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq.compact
+        side_load = foreign_keys.any? ? @association.klass.find(foreign_keys) : []
+        json_model_data = side_load.map { |model| model_serializer(model).as_json(model) }
         { @association.plural_name.to_sym => json_model_data, meta: { } }
       end
 
       def side_load_has_many
         has_association_relation do |options|
           if join_table = @association.options[:through]
-            options.scope = options.scope.joins(join_table)
+            options.scope = options.scope.joins(join_table).distinct
             association_fk = @association.through_reflection.foreign_key.to_sym
             options.filters = { join_table => { association_fk => model_ids } }
           else

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -97,10 +97,6 @@ module RestPack::Serializer::SideLoading
         ":#{include} is not a valid include for #{self.model_class}"
     end
 
-    def url_from_association(association)
-      serializer_from_association_class(association).url
-    end
-
     def url_for_association(association)
       identifier = case association.macro
       when :belongs_to, :has_one
@@ -111,16 +107,13 @@ module RestPack::Serializer::SideLoading
 
         "?#{param}={#{key}.#{value}}"
       end
-
-      "/#{url_from_association(association)}#{identifier}"
+      serializer = RestPack::Serializer.select_association_serializer(association)
+      url_from_association = serializer.class.url
+      "/#{url_from_association}#{identifier}"
     end
 
     def can_include_options(association)
       @can_include_options.fetch(association.name.to_sym, {})
-    end
-
-    def serializer_from_association_class(association)
-      RestPack::Serializer::Factory.create(association.class_name)
     end
   end
 end

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -79,7 +79,7 @@ module RestPack::Serializer::SideLoading
 
     def select_association_from_possibles(possible_relations)
       possible_relations.each do |relation|
-        if association = self.model_class.reflect_on_association(relation)
+        if association = self.model_class.reflect_on_association(relation.to_sym)
           return association
         end
       end

--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.5.8'
+    VERSION = '0.5.9'
   end
 end

--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.5.7'
+    VERSION = '0.5.8'
   end
 end

--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.5.6'
+    VERSION = '0.5.7'
   end
 end

--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.5.7.pre1'
+    VERSION = '0.5.9'
   end
 end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :name
     t.string :album
   end
-  
+
   create_table "generic_metadata", force: true do |t|
     t.integer :linked_id
     t.string :linked_type
@@ -85,7 +85,8 @@ module MyApp
     has_many :payments
     has_many :fans, :through => :payments
     has_many :generic_metadata, as: :linked
-    
+    has_many :data_items, class_name: "GenericMetadatum", as: :linked
+
     has_and_belongs_to_many :stalkers
   end
 
@@ -138,7 +139,7 @@ module MyApp
     attr_accessible :name
     belongs_to :album, foreign_key: :album
   end
-  
+
   class GenericMetadatum < ActiveRecord::Base
     attr_accessible :some_stuff_about_the_link
     belongs_to :linked, polymorphic: true

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -27,7 +27,7 @@ module MyApp
   class ArtistSerializer
     include RestPack::Serializer
     attributes :id, :name, :website
-    can_include :albums, :songs, :fans, :stalkers
+    can_include :albums, :songs, :fans, :stalkers, :data_items
   end
 
   class FanSerializer
@@ -40,11 +40,11 @@ module MyApp
     attributes :id, :name
   end
 
-  class ProducerSerializer 
+  class ProducerSerializer
     include RestPack::Serializer
     attributes :id, :name
   end
-  
+
   class GenericMetadatumSerializer
     include RestPack::Serializer
     attributes :id, :some_stuff_about_the_link

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -4,6 +4,8 @@ describe RestPack::Serializer::Attributes do
   class CustomSerializer
     include RestPack::Serializer
     attributes :a, :b, :c
+    attributes :d, :e
+    optional :sometimes, :maybe
     attribute :old_attribute, :key => :new_key
     transform [:gonzaga], lambda { |name, model| model.send(name).downcase }
   end
@@ -11,17 +13,37 @@ describe RestPack::Serializer::Attributes do
   subject(:attributes) { CustomSerializer.serializable_attributes }
 
   it "correctly models specified attributes" do
-    expect(attributes.length).to be(5)
+    expect(attributes.length).to be(9)
   end
 
   it "correctly maps normal attributes" do
-    [:a, :b, :c].each do |attr|
+    [:a, :b, :c, :d, :e].each do |attr|
       expect(attributes[attr]).to eq(attr)
     end
   end
 
   it "correctly maps attribute with :key options" do
     expect(attributes[:new_key]).to eq(:old_attribute)
+  end
+
+  describe "optional attributes" do
+    let(:model) { OpenStruct.new(a: 'A', sometimes: 'SOMETIMES', gonzaga: 'GONZAGA') }
+    let(:context) { {} }
+    subject(:as_json) { CustomSerializer.as_json(model, context) }
+
+    context 'with no includes context' do
+      it "excludes by default" do
+        expect(as_json[:sometimes]).to eq(nil)
+      end
+    end
+
+    context 'with an includes context' do
+      let(:context) { { include_sometimes?: true } }
+
+      it "allows then to be included" do
+        expect(as_json[:sometimes]).to eq('SOMETIMES')
+      end
+    end
   end
 
   describe '#transform_attributes' do

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -57,13 +57,14 @@ describe RestPack::Serializer::Attributes do
   end
 
   describe "model as a hash" do
-    let(:model) { { a: 'A', 'b' => 'B' } }
+    let(:model) { { a: 'A', 'b' => 'B', c: false } }
 
     subject(:as_json) { CustomSerializer.as_json(model, include_gonzaga?: false) }
 
     it 'uses the transform method on the model attribute' do
       expect(as_json[:a]).to eq('A')
       expect(as_json[:b]).to eq('B')
+      expect(as_json[:c]).to eq(false)
     end
   end
 end

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -33,4 +33,15 @@ describe RestPack::Serializer::Attributes do
       expect(as_json[:gonzaga]).to eq('is a school')
     end
   end
+
+  describe "model as a hash" do
+    let(:model) { { a: 'A', 'b' => 'B' } }
+
+    subject(:as_json) { CustomSerializer.as_json(model, include_gonzaga?: false) }
+
+    it 'uses the transform method on the model attribute' do
+      expect(as_json[:a]).to eq('A')
+      expect(as_json[:b]).to eq('B')
+    end
+  end
 end

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -4,6 +4,8 @@ describe RestPack::Serializer::Attributes do
   class CustomSerializer
     include RestPack::Serializer
     attributes :a, :b, :c
+    attributes :d, :e
+    optional :sometimes, :maybe
     attribute :old_attribute, :key => :new_key
     transform [:gonzaga], lambda { |name, model| model.send(name).downcase }
   end
@@ -11,17 +13,37 @@ describe RestPack::Serializer::Attributes do
   subject(:attributes) { CustomSerializer.serializable_attributes }
 
   it "correctly models specified attributes" do
-    expect(attributes.length).to be(5)
+    expect(attributes.length).to be(9)
   end
 
   it "correctly maps normal attributes" do
-    [:a, :b, :c].each do |attr|
+    [:a, :b, :c, :d, :e].each do |attr|
       expect(attributes[attr]).to eq(attr)
     end
   end
 
   it "correctly maps attribute with :key options" do
     expect(attributes[:new_key]).to eq(:old_attribute)
+  end
+
+  describe "optional attributes" do
+    let(:model) { OpenStruct.new(a: 'A', sometimes: 'SOMETIMES', gonzaga: 'GONZAGA') }
+    let(:context) { {} }
+    subject(:as_json) { CustomSerializer.as_json(model, context) }
+
+    context 'with no includes context' do
+      it "excludes by default" do
+        expect(as_json[:sometimes]).to eq(nil)
+      end
+    end
+
+    context 'with an includes context' do
+      let(:context) { { include_sometimes?: true } }
+
+      it "allows then to be included" do
+        expect(as_json[:sometimes]).to eq('SOMETIMES')
+      end
+    end
   end
 
   describe '#transform_attributes' do
@@ -31,6 +53,18 @@ describe RestPack::Serializer::Attributes do
 
     it 'uses the transform method on the model attribute' do
       expect(as_json[:gonzaga]).to eq('is a school')
+    end
+  end
+
+  describe "model as a hash" do
+    let(:model) { { a: 'A', 'b' => 'B', c: false } }
+
+    subject(:as_json) { CustomSerializer.as_json(model, include_gonzaga?: false) }
+
+    it 'uses the transform method on the model attribute' do
+      expect(as_json[:a]).to eq('A')
+      expect(as_json[:b]).to eq('B')
+      expect(as_json[:c]).to eq(false)
     end
   end
 end

--- a/spec/serializable/side_loading/belongs_to_spec.rb
+++ b/spec/serializable/side_loading/belongs_to_spec.rb
@@ -67,6 +67,19 @@ describe RestPack::Serializer::SideLoading do
         end
       end
 
+      context 'without an associated model' do
+        let!(:b_side) { FactoryGirl.create(:song, album: nil) }
+        let(:models) { [b_side] }
+
+        context 'when including :albums' do
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+
+          it 'return a hash with no data' do
+            side_loads.should == { :meta => {}, :albums => [] }
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/serializable/side_loading/has_many_spec.rb
+++ b/spec/serializable/side_loading/has_many_spec.rb
@@ -65,6 +65,17 @@ describe RestPack::Serializer::SideLoading do
             side_loads[:meta][:fans][:page].should == 1
             side_loads[:meta][:fans][:count].should == expected_count
           end
+
+          context "when there are shared fans" do
+            before do
+              artist_1.fans << artist_2.fans.first
+            end
+            it "should not include duplicates in the linked resource collection" do
+              expected_count = (artist_1.fans + artist_2.fans).uniq.count
+              expect(side_loads[:fans].count).to eq(expected_count)
+              expect(side_loads[:meta][:fans][:count]).to eq(expected_count)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
merged the latest restpack code with our dev branch. Allow serializers to be selected based on relation names and not just the association class name. Think `project_roles` with class_name `AccessControlList`.
